### PR TITLE
Changed equality statement to be based on the Bot's user

### DIFF
--- a/SDGDiscordBot.js
+++ b/SDGDiscordBot.js
@@ -29,7 +29,7 @@ bot.on("message", function(message)
 	if(lowerCaseMessage.includes("and his name is") ||
 		lowerCaseMessage.includes("and his name was") ||
 		message.content.includes("\uD83C\uDFBA") &&
-		message.author.name != "ShameBot"){ //Unicode trumpet
+		!message.author.equals(bot.user)){ //Unicode trumpet
 		
 		//Reply message	
 		bot.reply(message, "\uD83C\uDFBA\uD83C\uDFBA\uD83C\uDFBA\uD83C\uDFBA**JOHN CENA!**\uD83C\uDFBA\uD83C\uDFBA\uD83C\uDFBA\uD83C\uDFBA");


### PR DESCRIPTION
When we go to run this locally, we end up having to create our own bot, with it's own name. When that happens, we can no longer use the name as comparison or it caused an infinite loop.

I believe this should fix that and allow the bot to be run regardless of it's name. A message's author is a User object. The bot is a client, but it also has a User object. The User object in Discord extends the Equality class, which allows for the .equals() function for comparison.