### PR TITLE
Fix cenaimage folder name as the code looks for a camel cased name

### DIFF
--- a/SDGDiscordBot.js
+++ b/SDGDiscordBot.js
@@ -13,7 +13,7 @@ var AuthDetails = require("./auth.json");
 
 var botStartTime = new Date();
 
-var cenaImageFolder = "./cenaimages/";
+var cenaImageFolder = "./cenaImages/";
 
 var cenaImageArray = new Array();
 cenaImageArray = fs.readdirSync(cenaImageFolder);//Loops through a given folder and creates an array of file names


### PR DESCRIPTION
Pretty quick one just to fix this. Issue became a blocker on Ubuntu 15.10 x64

`Error: ENOENT: no such file or directory, scandir './cenaimages/'
    at Error (native)
    at Object.fs.readdirSync (fs.js:856:18)
    at Object.<anonymous> ([redacted]/SDG_Discord_Bot/SDGDiscordBot.js:19:21)
    at Module._compile (module.js:413:34)
    at Object.Module._extensions..js (module.js:422:10)
    at Module.load (module.js:357:32)
    at Function.Module._load (module.js:314:12)
    at Function.Module.runMain (module.js:447:10)
    at startup (node.js:146:18)
    at node.js:404:3
`