### PR TITLE
Updating to Discord.js version 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "description": "Shameful Display Gaming Discord Bot",
   "main": "SDGDiscordBot.js",
   "dependencies": {
-    "discord.js": "^7.0.1",
-    "mongodb": "^2.1.21",
-    "winston": "^2.2.0",
     "cheerio": "^0.20.0",
-    "request": "^2.74.0"
+    "discord.js": "github:hydrabolt/discord.js#indev-old",
+    "mongodb": "^2.1.21",
+    "request": "^2.74.0",
+    "winston": "^2.2.0"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
Version 9 is out now but requires some re-work. This is a duct tape solution.

Signed-off-by: David J King <davidjking@me.com>