### PR TITLE
Server Logging via bot channel

### DIFF
--- a/SDGDiscordBot.js
+++ b/SDGDiscordBot.js
@@ -412,4 +412,8 @@ bot.on("messageUpdated", function(originalMessage, updatedMessage){
   ServerLog.editedMessageEvent(originalMessage, updatedMessage);
 });
 
+bot.on("messageDeleted", function(deletedMessage, channel){
+  ServerLog.deletedMessageEvent(deletedMessage, channel);
+});
+
 bot.loginWithToken(AuthDetails.token);

--- a/SDGDiscordBot.js
+++ b/SDGDiscordBot.js
@@ -416,4 +416,8 @@ bot.on("messageDeleted", function(deletedMessage, channel){
   ServerLog.deletedMessageEvent(deletedMessage, channel);
 });
 
+bot.on("channelCreated", function(newChannel){
+  ServerLog.newChannelEvent(newChannel);
+});
+
 bot.loginWithToken(AuthDetails.token);

--- a/SDGDiscordBot.js
+++ b/SDGDiscordBot.js
@@ -22,6 +22,8 @@ var TableCatchManager = require("./modules/tableCatcherModule.js")
 var CatchManager = new TableCatchManager(bot);
 var InfoManager = require("./modules/informationModule.js")
 var InfoReplies = new InfoManager(bot);
+var ServerLogManager = require("./modules/serverLogModule.js")
+var ServerLog = new ServerLogManager(bot);
 var request = require("request"),
   cheerio = require("cheerio");
 
@@ -403,6 +405,11 @@ bot.on("message", function(message)
 		CatchManager.tableCatcherReply(message);
 	}
 
+});
+
+// Server Logging
+bot.on("messageUpdated", function(originalMessage, updatedMessage){
+  ServerLog.editedMessageEvent(originalMessage, updatedMessage);
 });
 
 bot.loginWithToken(AuthDetails.token);

--- a/modules/serverLogModule.js
+++ b/modules/serverLogModule.js
@@ -1,0 +1,15 @@
+var ServerLogManager = function (bot){
+
+  this.editedMessageEvent = function (originalMessage, updatedMessage) {
+    var serverLogChannel = bot.channels.get("name", "serverlog");
+
+    bot.sendMessage(serverLogChannel, '**Updated Message**\n' + originalMessage.author.username + '#' +
+    originalMessage.author.discriminator + '' + ' updated their message in the ' +
+    originalMessage.channel + ' channel\n**Original Message:** \n' +
+    originalMessage.cleanContent + '\n**Updated Message:** \n' +
+    updatedMessage.cleanContent + '\n');
+  }
+
+}
+
+module.exports = ServerLogManager;

--- a/modules/serverLogModule.js
+++ b/modules/serverLogModule.js
@@ -19,6 +19,13 @@ var ServerLogManager = function (bot){
     deletedMessage.cleanContent);
   }
 
+  this.newChannelEvent = function (newChannel) {
+    var serverLogChannel = bot.channels.get("name", "serverlog");
+
+    bot.sendMessage(serverLogChannel, '**New Channel Created**\n' + 'A new channel named ' +
+    newChannel + ' was created.\n');
+  }
+
 }
 
 module.exports = ServerLogManager;

--- a/modules/serverLogModule.js
+++ b/modules/serverLogModule.js
@@ -10,6 +10,15 @@ var ServerLogManager = function (bot){
     updatedMessage.cleanContent + '\n');
   }
 
+  this.deletedMessageEvent = function (deletedMessage, channel) {
+    var serverLogChannel = bot.channels.get("name", "serverlog");
+
+    bot.sendMessage(serverLogChannel, '**Deleted Message**\n' + deletedMessage.author.username + '#' +
+    deletedMessage.author.discriminator + '' + ' deleted this message in the ' +
+    deletedMessage.channel + ' channel\n**Deleted Message:** \n' +
+    deletedMessage.cleanContent);
+  }
+
 }
 
 module.exports = ServerLogManager;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "SDGDiscordBot.js",
   "dependencies": {
     "cheerio": "^0.20.0",
-    "discord.js": "github:hydrabolt/discord.js#indev-old",
+    "discord.js": "github:hydrabolt/discord.js#v8",
     "mongodb": "^2.1.21",
     "request": "^2.74.0",
     "winston": "^2.2.0"


### PR DESCRIPTION
Right now this will need the channel "serverlog" manually created and the bot will need permission to read/write to that channel. In the future it will handle creation and channel updates itself (or at least that's the plan) but considering we wanted to push this out now for message pinning i didn't want to hold back the basic functionality.