### PR TITLE
Fix Honor attribution for users with nicknames

### DIFF
--- a/SDGDiscordBot.js
+++ b/SDGDiscordBot.js
@@ -98,7 +98,7 @@ bot.on("message", message => {
 		for (i = 0; i < messageTokens.length; i++){ //step through tokenized message array
 			if (messageTokens[i].charAt(0) == '<'){ //check if word is a mention by checking for the opening char
         var legitMention = false; //initialize flag for legitimate mentions
-				slicedStringMention = messageTokens[i].slice(2, -1); //extract user ID from mention in the message (removing <@ and >)
+				slicedStringMention = messageTokens[i].slice(2, -1).toString().replace(/[!]/g, ''); //extract user ID from mention in the message (removing <@ and >) && removes ! from userIDs with a nickname
 				for (var userObj of mentionsArray){ //step through each object in the mentions array
           if (userObj.id == slicedStringMention && !userObj.equals(message.author) ) {// check to see if the user ID found matches a real mention
 						legitMention = true;


### PR DESCRIPTION
Any user that has a nickname will have their UserID returned as !USERID

Example from actual message content:
content: '<@!157697608784019456> ++ <@169093722909310977> ++'

(one user with a nickname and one without)

Testing/validation example 
<img width="454" alt="screen shot 2017-11-27 at 10 05 01 pm" src="https://user-images.githubusercontent.com/914013/33300841-6f4f5e2e-d3c0-11e7-9163-6308ca1d9127.png">
